### PR TITLE
Add versioned dep on scrapy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup_params = dict(
         'twisted',
         'python-dateutil',
         'decorator',
-        'scrapy',
+        'scrapy>0.9',
         'argparse',
         'mock',
         'PyYAML',


### PR DESCRIPTION
scrapy 0.8 isn't returning data returned from callbacks. I haven't dug into why, but we should make the dep obvious.
