### PR TITLE
Make importlib dependency only take place if you need it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,17 @@ setup_params = dict(
         'argparse',
         'mock',
         'PyYAML',
-        'importlib',
         'autoresponse>=0.2',
     ],
 )
+
+### Python 2.7 already has importlib. Because of that,
+### we can't put it in install_requires. We test for
+### that here; if needed, we add it.
+try:
+    import importlib
+except ImportError:
+    install_requires.append('importlib')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes the errors you can read here: http://vm3.openhatch.org:8080/job/oh-bugimporters/22/console
