### PR TITLE
Removing vestigial references

### DIFF
--- a/bugimporters/base.py
+++ b/bugimporters/base.py
@@ -89,7 +89,7 @@ class BugImporter(object):
     # Importer functions that may require overloading #
     ###################################################
     def __init__(self, tracker_model, reactor_manager=None, bug_parser=None,
-            data_transits=None, extended_scrape=False):
+            extended_scrape=False):
         # Store the tracker model
         self.tm = tracker_model
         # Store the reactor manager
@@ -110,13 +110,6 @@ class BugImporter(object):
         self.deferred_urls = {}
         # Take an optional bug_parser to usee with this importer.
         self.bug_parser = bug_parser
-
-        self.data_transits = data_transits
-
-    def finish_import(self):
-        # This importer has finished, so let the reactor manager know that it
-        # may be able to stop the reactor.
-        self.rm.maybe_quit()
 
     ##########################################################
     # Importer functions that definitely require overloading #

--- a/bugimporters/main.py
+++ b/bugimporters/main.py
@@ -107,7 +107,6 @@ class BugImportSpider(scrapy.spider.BaseSpider):
             bug_importer = bug_import_class(
                 obj, reactor_manager=None,
                 bug_parser=bug_parser_class,
-                data_transits=None,
                 extended_scrape=self.extended_scrape)
             yield (obj, bug_importer)
 

--- a/bugimporters/tests/test_roundup.py
+++ b/bugimporters/tests/test_roundup.py
@@ -31,8 +31,7 @@ class TestRoundupBugImporter(object):
                 ))
         cls.im = bugimporters.roundup.RoundupBugImporter(
             cls.tm,
-            bugimporters.tests.ReactorManager(),
-            data_transits=None)
+            bugimporters.tests.ReactorManager())
 
     def test_bug_import_works_with_comma_separated_closed_status(self):
         self.setup_class()
@@ -168,8 +167,7 @@ class TestRoundupBugsFromPythonProject(object):
                 ))
         cls.im = bugimporters.roundup.RoundupBugImporter(
             cls.tm,
-            bugimporters.tests.ReactorManager(),
-            data_transits=None)
+            bugimporters.tests.ReactorManager())
 
     def test_bug_import_open(self):
         # Check the number of Bugs present.

--- a/bugimporters/tests/test_trac.py
+++ b/bugimporters/tests/test_trac.py
@@ -34,8 +34,7 @@ class TestTracBugImporter(object):
 
     def setup_class(cls):
         cls.tm = TrackerModel()
-        cls.im = TracBugImporter(cls.tm, ReactorManager(),
-                data_transits=importer_data_transits)
+        cls.im = TracBugImporter(cls.tm, ReactorManager())
 
     def test_provide_existing_bug_urls(self):
         self.setup_class()
@@ -273,8 +272,7 @@ class TestTracBugParser(object):
 
     def setup_class(cls):
         cls.tm = TrackerModel()
-        cls.im = TracBugImporter(cls.tm, ReactorManager(),
-                data_transits=importer_data_transits)
+        cls.im = TracBugImporter(cls.tm, ReactorManager())
 
         # Set up the Twisted TrackerModels that will be used here.
         cls.tm = TrackerModel(


### PR DESCRIPTION
I paired with Asheesh on this. 

We removed the functions 
`log_error` and `finish_import`
and the variable
`data_transits`

We found these using vulture
https://github.com/myint/vulture

There appears to be a lot of other vestigial code as well. Will reserve for future pull requests.
