### PR TITLE
Add DOWNLOAD_DELAY=0.5 to Scrapy config

### DIFF
--- a/bugimporters/main.py
+++ b/bugimporters/main.py
@@ -44,6 +44,7 @@ def main(raw_arguments):
                        '-s', 'CONCURRENT_REQUESTS_PER_DOMAIN=1',
                        '-s', 'CONCURRENT_REQUESTS=200',
                        '-s', 'DEPTH_PRIORITY=1',
+                       '-s', 'DOWNLOAD_DELAY=0.5',  # per host
                        '-s', 'SCHEDULER_DISK_QUEUE=scrapy.squeue.PickleFifoDiskQueue',
                        '-s', 'SCHEDULER_MEMORY_QUEUE=scrapy.squeue.FifoMemoryQueue',
                        '-a', 'extended_scrape=%s' % (args.extended_scrape)


### PR DESCRIPTION
At the time of writing, oh-bugimporters has difficulty downloading
all the bugs it wants to from github.com.

@ehashman discovered that GitHub throttles API requests after
5000 per hour.

The Scrapy DOWNLOAD_DELAY setting affects only "consecutive pages
from the same website", so we should still see a sizeable amount
of parallelism in our crawling after this change. However,
since this setting applies to all domains, we might still
see a general slowdown.