### PR TITLE
Provide -y to apt-get invocations

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -44,10 +44,10 @@ following commands in your command prompt/terminal emulator.
 
    If on Debian or Ubuntu, run::
 
-      sudo apt-get install libxml2-dev
-      sudo apt-get build-dep python-lxml
-      sudo apt-get install libffi-dev
-      sudo apt-get install libssl-dev
+      sudo apt-get install -y libxml2-dev
+      sudo apt-get build-dep -y python-lxml
+      sudo apt-get install -y libffi-dev
+      sudo apt-get install -y libssl-dev
  
    If on Fedora (tested on Fedora 21), run::
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -48,6 +48,7 @@ following commands in your command prompt/terminal emulator.
       sudo apt-get build-dep -y python-lxml
       sudo apt-get install -y libffi-dev
       sudo apt-get install -y libssl-dev
+      sudo apt-get build-dep -y python-yaml
  
    If on Fedora (tested on Fedora 21), run::
 


### PR DESCRIPTION
This way, people copy-pasting from the instructions won't enter a situation where one line of shell commands becomes the input to APT, resulting in APT not actually executing anything.